### PR TITLE
Run multiple gossfiles

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -27,6 +27,11 @@ func main() {
 			Usage:  "Goss file to read from / write to",
 			EnvVar: "GOSS_FILE",
 		},
+		cli.StringSliceFlag{
+			Name:   "additional-gossfiles, ga",
+			Usage:  "Addtional goss files to read from for validate/serve",
+			EnvVar: "GOSS_ADDITIONAL_FILES",
+		},
 		cli.StringFlag{
 			Name:   "vars",
 			Usage:  "json/yaml file containing variables for template",
@@ -145,6 +150,10 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
+				if len(c.GlobalStringSlice("additional-gossfiles")) > 0 {
+					fmt.Printf("Render does not work with additional-gossfiles")
+					os.Exit(1)
+				}
 				fmt.Print(goss.RenderJSON(c))
 				return nil
 			},

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -151,7 +151,7 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				if len(c.GlobalStringSlice("additional-gossfiles")) > 0 {
-					fmt.Printf("Render does not work with additional-gossfiles")
+					fmt.Printf("Render does not work with additional-gossfiles\n")
 					os.Exit(1)
 				}
 				fmt.Print(goss.RenderJSON(c))

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -28,7 +28,7 @@ func main() {
 			EnvVar: "GOSS_FILE",
 		},
 		cli.StringSliceFlag{
-			Name:   "additional-gossfiles, ga",
+			Name:   "additional-gossfiles, a",
 			Usage:  "Addtional goss files to read from for validate/serve",
 			EnvVar: "GOSS_ADDITIONAL_FILES",
 		},

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -56,7 +56,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --gossfile, -g "./goss.yaml"	Goss file to read from / write to [$GOSS_FILE]
-   --additional-gossfiles, -ag  Additional goss files to run 
+   --additional-gossfiles, -a   Additional goss files to run 
    --vars value                 json/yaml file containing variables for template [$GOSS_VARS]
    --package 			Package type to use [rpm, deb, apk, pacman]
    --help, -h			show help
@@ -74,6 +74,13 @@ The file to use when reading/writing tests. Use `-g -` to read from `STDIN`.
 Valid formats:
 * **YAML** (default)
 * **JSON**
+
+### -a additional_gossfile
+Additional files to read tests from. Not compatible with [render](#render).
+
+Behaves differently to [gossfile](#gossfile). This does not attempt to merge gossfiles together, so any tests that have the same ID will all execute instead of being overwritten.
+
+Multiple files can be specified using `-a file1.yaml -a file2.yaml`.
 
 ### --vars
 The file to read variables from when rendering gossfile [templates](#templates).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -56,6 +56,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --gossfile, -g "./goss.yaml"	Goss file to read from / write to [$GOSS_FILE]
+   --additional-gossfiles, -ag  Additional goss files to run 
    --vars value                 json/yaml file containing variables for template [$GOSS_VARS]
    --package 			Package type to use [rpm, deb, apk, pacman]
    --help, -h			show help

--- a/serve.go
+++ b/serve.go
@@ -22,7 +22,7 @@ func Serve(c *cli.Context) {
 
 	health := healthHandler{
 		c:             c,
-		gossConfig:    getGossConfig(c),
+		gossConfigs:   getGossConfigs(c),
 		sys:           system.New(c),
 		outputer:      getOutputer(c),
 		cache:         cache,
@@ -44,7 +44,7 @@ type res struct {
 }
 type healthHandler struct {
 	c             *cli.Context
-	gossConfig    GossConfig
+	gossConfigs   []GossConfig
 	sys           *system.System
 	outputer      outputs.Outputer
 	cache         *cache.Cache
@@ -74,7 +74,7 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.sys = system.New(h.c)
 			log.Printf("%v: Stale cache, running tests", r.RemoteAddr)
 			iStartTime := time.Now()
-			out := validate(h.sys, h.gossConfig, h.maxConcurrent)
+			out := validate(h.sys, h.gossConfigs, h.maxConcurrent)
 			var b bytes.Buffer
 			exitCode := h.outputer.Output(&b, out, iStartTime, outputConfig)
 			resp = res{exitCode: exitCode, b: b}


### PR DESCRIPTION
Add a new global flag `--additional-gossfiles` to specify additional gossfiles to run in addition to what is specified by `-g`.

Only works with `serve` and `validate`. This is because we avoid merging the gossfiles together entirely and can't produce a single YAML/JSON file with all the tests.

This is motivated by wanting to run multiple gossfiles that have conflicting keys in them. Since the keys used are file paths/users/services/etc, it isn't possible to specify different tests in different gossfiles for a single resource due to the behaviour of `mergeGoss`.

Modifying `mergeGoss` to perform deep merges is not an option, as there are users (#150) who rely on the overwriting behaviour to mask tests.